### PR TITLE
ci: uv publish en release:published, actualiza acciones

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,19 +1,17 @@
 name: Publish to PyPI
 
 on:
-  push:
-    tags:
-      - "*"
-  
+  release:
+    types: [published]
+
 jobs:
   pypi-publish:
-    name: upload release to PyPI
+    name: Publish to PyPI
     runs-on: ubuntu-latest
-    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
     permissions:
       id-token: write
     steps:
-      - uses: actions/checkout@v3
-      - uses: astral-sh/setup-uv@v5
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v7
       - run: uv build
-      - uses: pypa/gh-action-pypi-publish@release/v1
+      - run: uv publish


### PR DESCRIPTION
Closes #8

## Cambios

- Trigger: `push: tags: ["*"]` → `release: types: [published]`
- Reemplaza `pypa/gh-action-pypi-publish` por `uv publish`
- `actions/checkout` v3 → v4, `setup-uv` v5 → v7